### PR TITLE
Feature/specify path

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,14 @@ git2json
   .run({fields: exportedFields})
   .then(json => console.log(json));
 ```
+
+You can also specify a path for the git repository. Just like the above options, doing so is optional with sane defaults. Here is an example use case combining multiple git commit logs.
+
+```javascript
+const git2json = require('@fabien0102/git2json');
+const paths = ['~/etc', '~/src/hack/git2json'];
+
+const logPs = paths.map(path => git2json.run({ path }));
+
+Promise.all(logPs).then(json => [].concat(...json)).then(console.log);
+```

--- a/src/git2json.js
+++ b/src/git2json.js
@@ -23,18 +23,20 @@ const defaultFields = {
 
 /**
  * Execute git log on current folder and return a pretty object
- * 
+ *
  * @param {object} [options]
  * @param {object} [options.fields] - fields to exports
+ * @param {string} [options.path] - path of target git repo
  * @return {Promise}
  */
 function git2json({
-  fields = defaultFields
+  fields = defaultFields,
+  path = process.cwd()
 } = {}) {
   const exec = require('child_process').exec; // this require can't be global for mocking issue
   const keys = Object.keys(fields);
   const prettyKeys = keys.map(a => fields[a].value).join('%x00');
-  const gitLogCmd = `git log --pretty=format:"%x01${prettyKeys}%x01" --numstat --date-order`;
+  const gitLogCmd = `git -C ${path} log --pretty=format:"%x01${prettyKeys}%x01" --numstat --date-order`;
 
   return new Promise((resolve, reject) => {
     exec(gitLogCmd, (err, stdout, stderr) => {


### PR DESCRIPTION
# Summary
Added an additional optional argument that allows the consumer of the API to specify the target git repository.  

# Reason
[This codepen](https://codepen.io/fielding/pen/bLEPOq) displays git(not just GitHub) and codepen activity in a manner like the GitHub contribution calendars on GitHub profiles. Initially, it was GitHub and not git activity and I used data provided by Github. Since not all repositories I work on are on Github, or any repo hosting for that matter, I decided I wanted to create a data source representing all my git activity. Future git commits are easily added to the source via a git hook, but I needed to gather the history of the existing repositories. 

While this technically didn't require altering git2json to achieve, it resulted in much more eloquent code.

