### PR TITLE
[WIP] Migrate git2json from being exec() based to being spawn()based

### DIFF
--- a/__mocks__/child_process.js
+++ b/__mocks__/child_process.js
@@ -1,5 +1,0 @@
-const child_process = jest.genMockFromModule('child_process');
-
-child_process.__setExecFn = execFn => child_process.exec = execFn;
-
-module.exports = child_process;

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "license": "MIT",
   "devDependencies": {
     "codeclimate-test-reporter": "^0.4.0",
-    "jest": "18.1.0"
+    "jest": "18.1.0",
+    "mock-spawn": "^0.2.6"
   }
 }

--- a/src/git2json.js
+++ b/src/git2json.js
@@ -34,7 +34,7 @@ function git2json({ fields = defaultFields, path = process.cwd() } = {}) {
   const { spawn } = require('child_process');
   const keys = Object.keys(fields);
   const prettyKeys = keys.map(a => fields[a].value).join('%x00');
-  const gitLogCmd = `git -C ${path} log --pretty=format:"%x01${prettyKeys}%x01" --numstat --date-order`;
+  const gitLogCmd = `git -C ${path} log --pretty=format:%x01${prettyKeys}%x01 --numstat --date-order`;
   const [cmd, ...args] = gitLogCmd.split(' ');
 
   return new Promise((resolve, reject) => {

--- a/test/git2json.test.js
+++ b/test/git2json.test.js
@@ -1,12 +1,16 @@
 const git2json = require('../src/git2json').run;
+const mockSpawn = require('mock-spawn');
 const fs = require('fs');
 
-jest.mock('child_process');
+jest.mock('child_process', () => ({spawn: mockSpawn()}));
+const child_process = require('child_process');
 
 describe('git2json.run', () => {
 
   it('should parse correctly git log', () => {
-    require('child_process').__setExecFn((cmd, callback) => callback(null, fs.readFileSync('test/gitlog.mock', 'utf8')));
+    child_process.spawn.setDefault(
+      child_process.spawn.simple(0, fs.readFileSync('test/gitlog.mock', 'utf8'))
+    );
     const expected = JSON.parse(fs.readFileSync('test/gitlog.expected', 'utf8'));
 
     return git2json()
@@ -14,14 +18,19 @@ describe('git2json.run', () => {
   });
 
   it('should fail on error', () => {
-    require('child_process').__setExecFn((cmd, callback) => callback(new Error('any error')));
+    child_process.spawn.setDefault(function (cb) {
+      this.emit('error', new Error('any error'));
+      cb(1);
+    });
 
     return git2json()
       .catch(err => expect(err.message).toEqual('any error'));
   });
 
   it('should override default fields', () => {
-    require('child_process').__setExecFn((cmd, callback) => callback(null, fs.readFileSync('test/gitlog-only-commit.mock', 'utf8')));
+    child_process.spawn.setDefault(
+      child_process.spawn.simple(0, fs.readFileSync('test/gitlog-only-commit.mock', 'utf8'))
+    );
     const expected = JSON.parse(fs.readFileSync('test/gitlog-only-commit.expected', 'utf8'));
 
     return git2json({ fields: { hash: { value: '%H' } } })
@@ -29,7 +38,9 @@ describe('git2json.run', () => {
   });
 
   it('should parse \'-\' character for stats correctly', () => {
-    require('child_process').__setExecFn((cmd, callback) => callback(null, fs.readFileSync('test/gitlog-NaN-stats.mock', 'utf8')));
+    child_process.spawn.setDefault(
+      child_process.spawn.simple(0, fs.readFileSync('test/gitlog-NaN-stats.mock', 'utf8'))
+    );
     const expected = JSON.parse(fs.readFileSync('test/gitlog-NaN-stats.expected', 'utf8'));
 
     return git2json()


### PR DESCRIPTION
:warning: **WIP: I must shamelessly ask for assistance with jest, mocks and adapting the tests for this.** :construction:
--------------------------------------------------------------------------------

This fixes the stdout maxBuffer exceeded issue  (#1) that prevented the use of git2json on any repository with git log output exceeding child_process.exec()'s default maxBuffer setting of 200KB. Rather than upping the default buffer size of child_process.exec() to a size that MIGHT accommodate MOST of the large repos, I felt the correct decision was to replace child_process.exec() with child_process.spawn.

Luckily it was rather straightforward. Only one additional change that adapts how the command/args are passed to each function accompanies the bulk changes that substitute spawn() for exec().

I ran a few small tests in the form of quick boneheaded scripts, but the primary indicator of it working came from diffing the output of the project that utilizes git2json. I compared the previous output, output from a version of git2json where I increased the maxbuffer option on exec(), and then the output of the spawn() version. 

Unfortunately, I am a complete newbie when it comes to jest, and as much as I hate to admit it, to mocking in general. I almost had something working, but I felt like I was missing some fundamentals from the jest handbook haha. For now, this lacks tests until I can read over the docs, or hopefully, somebody can school my newb self with some jest/mock knowledge.

Cheers, :beers:
Fielding

--------------------------------------------------------------------------------
**Ref:**
* https://www.hacksparrow.com/difference-between-spawn-and-exec-of-node-js-child_process.html


