### PR TITLE
Add support for extraLogOptions

### DIFF
--- a/src/git2json.js
+++ b/src/git2json.js
@@ -29,7 +29,7 @@ const defaultFields = {
  * @param {string} [options.path] - path of target git repo
  * @return {Promise}
  */
-function git2json({ fields = defaultFields, path = process.cwd(), paths = path } = {}) {
+function git2json({ fields = defaultFields, path = process.cwd(), paths = path, extraLogOptions = [] } = {}) {
   // this require can't be global for mocking issue
   const { spawn } = require('child_process');
   const keys = Object.keys(fields);
@@ -43,7 +43,7 @@ function git2json({ fields = defaultFields, path = process.cwd(), paths = path }
     '--numstat',
     '--date-order',
     '--all'
-  ]);
+  ].concat(extraLogOptions));
 
   return Promise.all(
     args.map(


### PR DESCRIPTION
I needed to pass some extra arguments into this tool and made the change to enable this. 

If you like this, i could add, the following to the readme.


Example specifying `extraLogOptions`:

```javascript
const git2json = require('@fabien0102/git2json');
const paths = ['~/etc', '~/src/hack/git2json'];
const extraLogOptions = ['origin/master', '--since=4.weeks', '--first-parent']

git2json
  .run({ paths, extraLogOptions })
  .then(console.log);
```